### PR TITLE
fix: [QBE-471] - [KMC Dashboard] - Locker Management - disable renew button. , fix: [QBE-470] - [KMC Dashboard] - User Management - Disable pricing button. fix: [QBE-469] - [KMC Dashboard] - Locker Management - Locker booking - Incorrect behavior upon clicking enter button. fix: Text transfor to capitalize and remove _ for Role texts.

### DIFF
--- a/app/configuration/page.tsx
+++ b/app/configuration/page.tsx
@@ -250,6 +250,7 @@ const ConfigurationPage = () => {
                         Users
                       </TabsTrigger>
                       <TabsTrigger
+                        disabled
                         value="pricing"
                         onClick={() => changeTab("pricing")}
                         className="w-full md:w-auto"
@@ -285,7 +286,9 @@ const ConfigurationPage = () => {
                                     <p className="text-sm truncate">
                                       {user.email}
                                     </p>
-                                    <p className="text-sm">{user.role}</p>
+                                    <p className="text-sm capitalize">
+                                      {user.role}
+                                    </p>
                                   </div>
                                   <span className="absolute top-0 right-0">
                                     <div className="p-2">

--- a/app/occupancy/action-cell.tsx
+++ b/app/occupancy/action-cell.tsx
@@ -302,6 +302,7 @@ const LockerRenewDoorAction = ({ locker }: any) => {
       <AlertDialog>
         <AlertDialogTrigger className="w-full">
           <Button
+            disabled
             onClick={() => setShowDialog(true)}
             className="w-full bg-primary"
           >

--- a/app/occupancy/create/page.tsx
+++ b/app/occupancy/create/page.tsx
@@ -535,7 +535,10 @@ const CreateLockerPage: React.FC = () => {
 
                       <div className="grid grid-cols-2 gap-2">
                         <Link href="/occupancy?status=vacant">
-                          <button className="w-full text-xs btn-secondary outline outline-gray-300 outline-1 p-2 rounded capitalize">
+                          <button
+                            type="button"
+                            className="w-full text-xs btn-secondary outline outline-gray-300 outline-1 p-2 rounded capitalize"
+                          >
                             Cancel
                           </button>
                         </Link>


### PR DESCRIPTION
## TICKET
- https://aiqueinnov.atlassian.net/browse/QBE-469
- https://aiqueinnov.atlassian.net/browse/QBE-470
- https://aiqueinnov.atlassian.net/browse/QBE-471

###
## Change Summary
 - Disabled `Renew` button for occupancy
 - Disabled `Pricing` tab for configuration
 - Text transform roles text to Capitalize, replace `_` with ` `
 - Handle on enter event when booking a locker correctly.


###
## Test Proofs
  _**- After fix**_
  = https://www.loom.com/share/53a0edbb8b6c40cd8b6241b784baddc9
  - ![Screenshot 2024-02-25 222005](https://github.com/MatAIQUE/kmc-dashboard/assets/148944044/796e151e-18a7-4878-9793-1dcb1aa5c5cb)
  - <img width="312" alt="renew-disabled" src="https://github.com/MatAIQUE/kmc-dashboard/assets/148944044/b81636a2-0538-4110-aca5-70dfdd2b20dc">


###
##
- [X] DEV
- [ ] STAGING
- [ ] PROD
- [X] BUG FIX
- [ ] HOT FIX
- [] ENHANCEMENT